### PR TITLE
Update GitPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click==8.0.0
 colorama==0.4.4
 gitdb==4.0.7
-GitPython==3.1.17
+GitPython==3.1.24
 termcolor==1.1.0
 yaspin==2.0.0
 importlib-metadata==3.4.0


### PR DESCRIPTION
v3.1.17 of GitPython was apparently removed from pipi, because it broke for some older python versions (e.g., 3.5)﻿
